### PR TITLE
adiciona/altera campos para highlight

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -41,8 +41,10 @@ class Query extends HttpRequest
   var $pt;
   var $d;
   var $hl;
-  var $hlField;
-  var $hlQ;
+  var $hlFl;
+  var $hlSnippets;
+  var $hlFragSize;
+  var $hlMethod;
   var $group;
   var $groupField;
   var $groupLimit;
@@ -92,8 +94,10 @@ class Query extends HttpRequest
     $url .= $this->pt();
     $url .= $this->d();
     $url .= $this->hl();
-    $url .= $this->hlField();
-    $url .= $this->hlQ();
+    $url .= $this->hlFl();
+    $url .= $this->hlSnippets();
+    $url .= $this->hlFragSize();
+    $url .= $this->hlMethod();
     $url .= $this->jsonFacet();
 
     $Response = new parent("get", $url);
@@ -183,22 +187,37 @@ class Query extends HttpRequest
     return "&hl=" . urlencode($this->hl);
   }
 
-  function hlQ()
+  function hlFl()
   {
-    if (empty($this->hlQ)) {
+    if (empty($this->hlFl)) {
       return "";
     }
-
-    return "&hl.q=" . urlencode($this->hlQ);
+    return "&hl.fl=" . urlencode($this->hlFl);
   }
 
-  function hlField()
+  function hlSnippets()
   {
-    if (empty($this->hlField)) {
+    if (empty($this->hlSnippets)) {
       return "";
     }
 
-    return "&hl.field=" . urlencode($this->hlField);
+    return "&hl.snippets=" . urlencode($this->hlSnippets);
+  }
+
+  function hlFragSize()
+  {
+    if (empty($this->hlFragSize)) {
+      return "";
+    }
+    return "&hl.fragsize=" . urlencode($this->hlFragSize);
+  }
+
+  function hlMethod()
+  {
+    if (empty($this->hlMethod)) {
+      return "";
+    }
+    return "&hl.method=" . urlencode($this->hlMethod);
   }
 
   function wt()


### PR DESCRIPTION
- adiciona `$hlFl` para definir campo de highlight
- adiciona `$hlSnippets` para definir número de partes de conteúdos a serem retornados no mesmo asset
- adiciona `$hlFragSize` para definir tamanho do trecho a ser retornado
- adiciona `$hlMethod` para definir o método do motor de busca no highlight. o mais recomendado é o `original` pois é rápido e - respeita o `hl.fragsize`